### PR TITLE
Remove unused code from deps

### DIFF
--- a/native-libs/deps/recipes/monerocorecustom/monerocorecustom.recipe
+++ b/native-libs/deps/recipes/monerocorecustom/monerocorecustom.recipe
@@ -1,7 +1,7 @@
 inherit lib
 
-version="4f29efe73f06af98037a65d2eb1332267555cd97"
-source="https://github.com/mymonero/monero-core-custom.git#${version}"
+version="36f6892dbe9fe6c7c87e8a52ca863c51f331fc7b"
+source="https://github.com/ExodusMovement/monero-core-custom.git#${version}"
 
 build() {
     mkdir -p $install_dir/repos/monero-core-custom

--- a/native-libs/deps/recipes/mymonerocorecpp/CMakeLists.txt
+++ b/native-libs/deps/recipes/mymonerocorecpp/CMakeLists.txt
@@ -24,7 +24,6 @@ include_directories("${MONERO_SRC}/multisig")
 include_directories("${MONERO_SRC}/cryptonote_core")
 include_directories("${MONERO_SRC}/cryptonote_protocol")
 include_directories("${MONERO_SRC}/wallet")
-include_directories("${MONERO_SRC}/rpc")
 include_directories("${MONERO_SRC}/mnemonics")
 include_directories("${MONERO_SRC}/contrib/libsodium/include") # support sodium/… paths
 include_directories("${MONERO_SRC}/contrib/libsodium/include/sodium")
@@ -67,27 +66,15 @@ set(
     ${MONERO_SRC}/crypto/crypto.cpp
     ${MONERO_SRC}/crypto/hash.c
     ${MONERO_SRC}/crypto/slow-hash-dummied.cpp
-    ${MONERO_SRC}/crypto/oaes_lib.c
     ${MONERO_SRC}/crypto/crypto-ops.c
     ${MONERO_SRC}/crypto/crypto-ops-data.c
     ${MONERO_SRC}/crypto/keccak.c
     ${MONERO_SRC}/crypto/chacha.c
     ${MONERO_SRC}/crypto/random.c
-    ${MONERO_SRC}/crypto/aesb.c
     ${MONERO_SRC}/crypto/tree-hash.c
-    ${MONERO_SRC}/crypto/hash-extra-blake.c
-    ${MONERO_SRC}/crypto/blake256.c
-    ${MONERO_SRC}/crypto/hash-extra-groestl.c
-    ${MONERO_SRC}/crypto/hash-extra-jh.c
-    ${MONERO_SRC}/crypto/hash-extra-skein.c
-    ${MONERO_SRC}/crypto/groestl.c
-    ${MONERO_SRC}/crypto/jh.c
-    ${MONERO_SRC}/crypto/skein.c
     ${MONERO_SRC}/cryptonote_core/cryptonote_tx_utils.cpp
     ${MONERO_SRC}/common/base58.cpp
-    ${MONERO_SRC}/common/threadpool.cpp
     ${MONERO_SRC}/common/aligned.c
-    ${MONERO_SRC}/common/util.cpp
     ${MONERO_SRC}/epee/src/hex.cpp
     ${MONERO_SRC}/epee/src/string_tools.cpp
     ${MONERO_SRC}/epee/src/memwipe.c

--- a/native-libs/deps/recipes/mymonerocorecpp/mymonerocorecpp.recipe
+++ b/native-libs/deps/recipes/mymonerocorecpp/mymonerocorecpp.recipe
@@ -1,8 +1,8 @@
 depends="boost monerocorecustom"
 inherit lib
 
-version="95b6528d919819aaeca2e35791edf414d9afe889"
-source="https://github.com/mymonero/mymonero-core-cpp.git#${version}"
+version="b72e653363db1cb2d654bd5c21ab01bea31675a0"
+source="https://github.com/ExodusMovement/mymonero-core-cpp.git#${version}"
 
 build() {
     case $target in


### PR DESCRIPTION
@Sekhmet ~This is WiP, just to test code removals.~
~Currently points to not specific commits, but branches -- but that is for testing only.~

Could you please confirm that this still builds and works in RN for you?
About 9-10k lines removed here, I believe those were unused.

We could continue dropping stuff after that.

Related branches:
* https://github.com/ExodusMovement/monero-core-custom/tree/react-native-integration
* https://github.com/ExodusMovement/mymonero-core-cpp/tree/react-native-integration
