### PR TITLE
Clean up native-libs Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sudo xcodebuild -license
 2. Install build tools
 
 ```bash
-brew install autoconf automake cmake git libtool pkgconfig protobuf astyle
+brew install autoconf automake cmake git pkgconfig protobuf
 ```
 
 2. Install SDK headers
@@ -86,7 +86,7 @@ Setup (once)
 # macOS 10.14.6 - Xcode 11.0
 sudo xcode-select --switch /Applications/Xcode.app
 sudo xcodebuild -license
-brew install autoconf automake cmake git libtool pkgconfig protobuf astyle
+brew install autoconf automake cmake git pkgconfig protobuf
 open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
 ```
 

--- a/native-libs/.gitignore
+++ b/native-libs/.gitignore
@@ -1,3 +1,2 @@
 Test
 xcuserdata
-Version.h

--- a/native-libs/Makefile
+++ b/native-libs/Makefile
@@ -2,24 +2,6 @@
 WORK_DIR ?= build
 INSTALL_PATH ?= /usr/local
 
-# Set latest Git revision as Version
-ifeq (,$(wildcard src/Version.h))
-$(shell cp "src/Version.h.in" "src/Version.h")
-endif
-
-GIT_REV = $(shell git rev-parse --short HEAD)
-SRC_REV = $(shell grep -o "\".*\"" src/Version.h)
-GIT_REV_COMPARE = $(shell [ $(GIT_REV) !=  $(SRC_REV) ] && echo true)
-
-ifeq ($(GIT_REV_COMPARE),true)
-$(shell sed -i '/#define ABC_VERSION ".*"/c\#define ABC_VERSION "$(GIT_REV)"' src/Version.h )
-endif
-
-# Set DEFAULT_HIDDENBITSKEY in CLI if passed as variable
-ifneq (,$(HIDDENBITSKEY))
-$(shell sed -i '/#define DEFAULT_HIDDENBITSKEY ".*"/c\#define DEFAULT_HIDDENBITSKEY "$(HIDDENBITSKEY)"' cli/Main.cpp )
-endif
-
 # Compiler options:
 CFLAGS   += -D_GNU_SOURCE -DDEBUG -g -Wall -fPIC -std=c99
 CXXFLAGS += -D_GNU_SOURCE -DDEBUG -g -Wall -fPIC -std=c++11
@@ -39,13 +21,8 @@ endif
 abc_sources = \
 	$(wildcard src/*.cpp)
 
-cli_sources = $(wildcard cli/*.cpp cli/*/*.cpp)
-test_sources = $(wildcard test/*.cpp)
-
 # Objects:
 abc_objects = $(addprefix $(WORK_DIR)/, $(addsuffix .o, $(basename $(abc_sources))))
-cli_objects = $(addprefix $(WORK_DIR)/, $(addsuffix .o, $(basename $(cli_sources))))
-test_objects = $(addprefix $(WORK_DIR)/, $(addsuffix .o, $(basename $(test_sources))))
 
 # Adjustable verbosity:
 V ?= 0
@@ -54,7 +31,7 @@ ifeq ($V,0)
 endif
 
 # Targets:
-all: $(WORK_DIR)/abc-cli check format-check
+all: $(WORK_DIR)/abc-cli check
 libnativecrypto.a:  $(WORK_DIR)/libnativecrypto.a
 libnativecrypto.so: $(WORK_DIR)/libnativecrypto.so
 
@@ -63,15 +40,6 @@ $(WORK_DIR)/libnativecrypto.a: $(abc_objects)
 
 $(WORK_DIR)/libnativecrypto.so: $(abc_objects)
 	$(RUN) $(CXX) -shared -Wl,-soname=libnativecrypto.so -o $@ $^ $(LDFLAGS) $(LIBS)
-
-format:
-	@astyle --options=astyle-options -Q --suffix=none --recursive --exclude=build --exclude=codegen --exclude=deps --exclude=minilibs "*.cpp" "*.hpp" "*.h"
-
-format-check:
-ifneq (, $(shell which astyle))
-	@astyle --options=astyle-options -Q --suffix=none --recursive --exclude=build --exclude=codegen --exclude=deps --exclude=minilibs "*.cpp" "*.hpp" "*.h" \
-	--dry-run | sed -n '/Formatted/s/Formatted/Needs formatting:/p'
-endif
 
 clean:
 	$(RM) -r $(WORK_DIR)

--- a/native-libs/src/.gitignore
+++ b/native-libs/src/.gitignore
@@ -1,3 +1,2 @@
 Test
 xcuserdata
-Version.h

--- a/native-libs/src/Version.h.in
+++ b/native-libs/src/Version.h.in
@@ -1,6 +1,0 @@
-#ifndef VERSION_h
-#define VERSION_h
-
-#define ABC_VERSION "1c3acc7"
-
-#endif


### PR DESCRIPTION
1. Remove Version.h related code.
2. Remove astyle checks.
3. Remove libtool from requirements (it's already available on macOS).