### PR TITLE
build: add option to build using local files

### DIFF
--- a/build-deps
+++ b/build-deps
@@ -2,6 +2,13 @@
 export ZERO_AR_DATE=1
 export SOURCE_DATE_EPOCH=0
 
+# List of dependencies that should be rebuilt.
+# If you specify dependency source that doesn't change (local directory)
+# add this dependency there so new files are copied during a build.
+reactive_deps=(
+    nativecrypto
+)
+
 MACOSV=$(sw_vers -productVersion)
 XCODEV=$(xcodebuild -version)
 
@@ -21,7 +28,11 @@ export BUILD_DIR=$CURRENT_DIR/native-libs/deps/build
 #fi
 
 # Do the build:
-touch native-libs/deps/recipes/nativecrypto/nativecrypto.recipe
+
+for dep in "${reactive_deps[@]}"; do
+    touch native-libs/deps/recipes/$dep/$dep.recipe
+done
+
 (
     targets=""
     targets="$targets nativecrypto.package-ios-universal"

--- a/native-libs/deps/classes/common
+++ b/native-libs/deps/classes/common
@@ -14,7 +14,13 @@ download() {
         hash=${hash%"$url"}
 
         # Download:
-        if [ $path != ${path%.git} ]; then
+        if [ -e $s ]; then
+            if [ -e $path ]; then
+                rm -rf $path
+            fi
+
+            cp -a $s $path
+        elif [ $path != ${path%.git} ]; then
             if [ -e "$path" ]; then
                 git --git-dir="$path" fetch -f "$url" +refs/heads/*:refs/heads/*
             else
@@ -51,7 +57,13 @@ unpack() {
         hash=${hash%"$url"}
 
         # Unpack:
-        if [ $path != ${path%.git} ]; then
+        if [ -e $s ]; then
+            if [ -e $work_dir ]; then
+                rm -rf $work_dir
+            fi
+
+            cp -a $path $work_dir
+        elif [ $path != ${path%.git} ]; then
             # Check out using git:
             for i in {0..7}; do
                 # Parallel checkouts will fail, so wait:


### PR DESCRIPTION
Currently, dependencies can be pulled from git or downloaded in .tar archives.
It's not ideal for development. This adds an option to specify source as a local file:

```bash
# mymonerocorecpp.recipe

source="/Users/sekhmet/Workspace/mymonero-core-cpp"
```

In addition, if you add it to `reactive_deps` it will build it using the latest files from the source.