### PR TITLE
Add native tests support

### DIFF
--- a/build-deps
+++ b/build-deps
@@ -2,6 +2,8 @@
 export ZERO_AR_DATE=1
 export SOURCE_DATE_EPOCH=0
 
+NATIVE_TESTS=$NATIVE_TESTS
+
 # List of dependencies that should be rebuilt.
 # If you specify dependency source that doesn't change (local directory)
 # add this dependency there so new files are copied during a build.
@@ -38,14 +40,18 @@ done
 (
     targets=""
 
-    if [ Darwin = $(uname -s) ]; then
-        targets="$targets nativecrypto.package-ios-universal"
-    fi
+    if [[ "$NATIVE_TESTS" -eq "1" ]]; then
+        targets="$targets nativecrypto.build-native"
+    else
+        if [ Darwin = $(uname -s) ]; then
+            targets="$targets nativecrypto.package-ios-universal"
+        fi
 
-    targets="$targets nativecrypto.build-android-arm"
-    targets="$targets nativecrypto.build-android-arm64"
-    targets="$targets nativecrypto.build-android-x86"
-    targets="$targets nativecrypto.build-android-x86_64"
+        targets="$targets nativecrypto.build-android-arm"
+        targets="$targets nativecrypto.build-android-arm64"
+        targets="$targets nativecrypto.build-android-x86"
+        targets="$targets nativecrypto.build-android-x86_64"
+    fi
 
     cd native-libs/deps
     make $targets $@

--- a/build-deps
+++ b/build-deps
@@ -57,6 +57,11 @@ done
     make $targets $@
 )
 
+if [[ "$NATIVE_TESTS" -eq "1" ]]; then
+    echo "Finished running tests."
+    exit 0
+fi
+
 # Copy the results locally:
 if [ Darwin = $(uname -s) ]; then
     mkdir -m 0775 -p ios/Headers

--- a/build-deps
+++ b/build-deps
@@ -58,6 +58,8 @@ done
 )
 
 if [[ "$NATIVE_TESTS" -eq "1" ]]; then
+    cd native-libs
+    make check V=1 T=1
     echo "Finished running tests."
     exit 0
 fi

--- a/native-libs/.gitignore
+++ b/native-libs/.gitignore
@@ -1,2 +1,1 @@
-Test
 xcuserdata

--- a/native-libs/Makefile
+++ b/native-libs/Makefile
@@ -1,6 +1,9 @@
+.PHONY: check clean
+
 # Build settings:
 WORK_DIR ?= build
 INSTALL_PATH ?= /usr/local
+PREFIX ?= deps/build/prefix
 
 # Compiler options:
 CFLAGS   += -D_GNU_SOURCE -DDEBUG -g -Wall -fPIC -std=c99
@@ -17,12 +20,20 @@ ifneq (,$(findstring android,$(CC)))
 	LIBS := $(filter-out -lpthread,$(LIBS)) -llog
 endif
 
+# Test-only setup
+T ?= 0
+ifeq ($T, 1)
+	CXXFLAGS += -I$(PREFIX)/native/include
+	LDFLAGS += -L$(PREFIX)/native/lib
+endif
+
 # Source files:
-abc_sources = \
-	$(wildcard src/*.cpp)
+abc_sources = $(wildcard src/*.cpp)
+test_sources = $(wildcard test/*.cpp)
 
 # Objects:
 abc_objects = $(addprefix $(WORK_DIR)/, $(addsuffix .o, $(basename $(abc_sources))))
+test_objects = $(addprefix $(WORK_DIR)/, $(addsuffix .o, $(basename $(test_sources))))
 
 # Adjustable verbosity:
 V ?= 0
@@ -31,7 +42,6 @@ ifeq ($V,0)
 endif
 
 # Targets:
-all: $(WORK_DIR)/abc-cli check
 libnativecrypto.a:  $(WORK_DIR)/libnativecrypto.a
 libnativecrypto.so: $(WORK_DIR)/libnativecrypto.so
 
@@ -40,6 +50,13 @@ $(WORK_DIR)/libnativecrypto.a: $(abc_objects)
 
 $(WORK_DIR)/libnativecrypto.so: $(abc_objects)
 	$(RUN) $(CXX) -shared -Wl,-soname=libnativecrypto.so -o $@ $^ $(LDFLAGS) $(LIBS)
+
+$(WORK_DIR)/abc-test: $(test_objects)
+	echo $(CXXFLAGS)
+	$(RUN) $(CXX) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+check: $(WORK_DIR)/abc-test
+	$(RUN) $<
 
 clean:
 	$(RM) -r $(WORK_DIR)

--- a/native-libs/deps/recipes/nativecrypto/nativecrypto.recipe
+++ b/native-libs/deps/recipes/nativecrypto/nativecrypto.recipe
@@ -16,11 +16,6 @@ build() {
     # Build:
     make $output V=1
 
-    # Native builds include unit tests and utilities:
-    if [ $target = native ]; then
-        make all V=1
-    fi
-
     # Install:
     mkdir -p $install_dir/lib
     cp $work_dir/$output $install_dir/lib

--- a/native-libs/test/main.cpp
+++ b/native-libs/test/main.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include <string>
+#include <serial_bridge_index.hpp>
+
+int main() {
+    std::string decoded = serial_bridge::decode_address(
+        "{\"address\":\"REMOVED\",\"nettype_string\":\"MAINNET\"}"
+    );
+
+    std::cout << decoded << std::endl;
+    return 0;
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "NATIVE_TESTS=1 yarn build",
+    "test": "NATIVE_TESTS=1 ./build-deps",
     "build": "yarn build:native",
     "prebuild:native": "rm -rf ios/Libraries android/jni/libs",
     "build:native": "./build-deps",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "main": "index.js",
   "scripts": {
+    "test": "NATIVE_TESTS=1 yarn build",
     "build": "yarn build:native",
     "prebuild:native": "rm -rf ios/Libraries android/jni/libs",
     "build:native": "./build-deps",


### PR DESCRIPTION
Depends on https://github.com/ExodusMovement/react-native-fast-crypto/pull/13

The goal of this is to allow testing changes in nativecrypto and its dependencies without the need of building all flavours and running Android/iOS app. Adding and testing changes to current code base has terrible workflow as each build requires ~5 minutes of work and 20 minutes of waiting.

The target:
You can run `yarn test` to have your (native) binaries run and execute a test script that validates functionality from the library.

Tested:
- [x] Can run methods from `mymonero-core-cpp`.

```
Build Started
Tue Nov  5 18:11:50 CET 2019
macOS 10.14.5 - Xcode 10.3
Build version 10G8
Running nativecrypto.download
Running nativecrypto.build-native
c++ -c -MD -D_GNU_SOURCE -DDEBUG -g -Wall -fPIC -std=c++11 -Ideps/build/prefix/native/include -o build/test/main.o test/main.cpp
echo -D_GNU_SOURCE -DDEBUG -g -Wall -fPIC -std=c++11 -Ideps/build/prefix/native/include
-D_GNU_SOURCE -DDEBUG -g -Wall -fPIC -std=c++11 -Ideps/build/prefix/native/include
c++ -o build/abc-test build/test/main.o -Ldeps/build/prefix/native/lib -lmymonerocorecpp -lboost_thread -lboost_system -lm
build/abc-test
{"err_msg":"Invalid address"}

Finished running tests.
✨  Done in 1.54s.
```