### PR TITLE
fix: clear sums exit code

### DIFF
--- a/generate-sums.sh
+++ b/generate-sums.sh
@@ -5,3 +5,5 @@ FILE=shasums.txt
 rm -rf $FILE
 shasum -a 256 ios/Libraries/* >> $FILE 2>/dev/null
 shasum -a 256 android/jni/libs/*/* >> $FILE 2>/dev/null
+
+exit 0


### PR DESCRIPTION
We redirect stderr to /dev/null but exit code remains non-zero.