### PR TITLE
fix: execute readSettings in AsyncTask

### DIFF
--- a/android/src/main/java/co/airbitz/fastcrypto/RNFastCryptoModule.java
+++ b/android/src/main/java/co/airbitz/fastcrypto/RNFastCryptoModule.java
@@ -3,17 +3,10 @@ package co.airbitz.fastcrypto;
 
 import android.os.AsyncTask;
 
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.WritableMap;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 public class RNFastCryptoModule extends ReactContextBaseJavaModule {
 
@@ -41,41 +34,9 @@ public class RNFastCryptoModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void readSettings(String directory, String filePrefix, Promise promise) {
-        try {
-            File file = new File(directory);
-
-            if (!file.exists()) throw new Exception("Folder does not exist");
-
-            File[] files = file.listFiles();
-
-            List<Integer> values = new ArrayList<>();
-
-            for (File childFile : files) {
-                String fileName = childFile.getName();
-                if (!fileName.startsWith(filePrefix) || !fileName.endsWith(".json") || fileName.contains("enabled")) continue;
-
-                String name = fileName.replace(filePrefix, "").replace(".json", "");
-
-                values.add(Integer.parseInt(name));
-            }
-
-            WritableMap responseMap = Arguments.createMap();
-
-            if (values.size() == 0) {
-                promise.resolve(responseMap);
-                return;
-            }
-
-            responseMap.putInt("size", values.size());
-            responseMap.putInt("oldest", Collections.min(values));
-            responseMap.putInt("latest", Collections.max(values));
-
-            promise.resolve(responseMap);
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            promise.reject("Err", ex);
-        }
+    public void readSettings(final String directory, final String filePrefix, final Promise promise) {
+        AsyncTask task = new ReadSettingsAsyncTask(directory, filePrefix, promise);
+        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, null);
     }
 
 }

--- a/android/src/main/java/co/airbitz/fastcrypto/ReadSettingsAsyncTask.java
+++ b/android/src/main/java/co/airbitz/fastcrypto/ReadSettingsAsyncTask.java
@@ -1,0 +1,64 @@
+package co.airbitz.fastcrypto;
+
+import android.os.AsyncTask;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.WritableMap;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ReadSettingsAsyncTask extends AsyncTask<Void, Void, Void> {
+    private final String directory;
+    private final String filePrefix;
+    private final Promise promise;
+
+    public ReadSettingsAsyncTask(String directory, String filePrefix, Promise promise) {
+        this.directory = directory;
+        this.filePrefix = filePrefix;
+        this.promise = promise;
+    }
+
+    @Override
+    protected Void doInBackground(Void... voids) {
+        try {
+            File file = new File(directory);
+
+            if (!file.exists()) throw new Exception("Folder does not exist");
+
+            File[] files = file.listFiles();
+
+            List<Integer> values = new ArrayList<>();
+
+            for (File childFile : files) {
+                String fileName = childFile.getName();
+                if (!fileName.startsWith(filePrefix) || !fileName.endsWith(".json") || fileName.contains("enabled")) continue;
+
+                String name = fileName.replace(filePrefix, "").replace(".json", "");
+
+                values.add(Integer.parseInt(name));
+            }
+
+            WritableMap responseMap = Arguments.createMap();
+
+            if (values.size() == 0) {
+                promise.resolve(responseMap);
+                return null;
+            }
+
+            responseMap.putInt("size", values.size());
+            responseMap.putInt("oldest", Collections.min(values));
+            responseMap.putInt("latest", Collections.max(values));
+
+            promise.resolve(responseMap);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            promise.reject("Err", ex);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Native calls are not executed in queue on Android so we are moving that `readSettings` call to `AsyncTask` similar to other Monero related calls.