### PR TITLE
feat: upgrade to v0.17.0.0

### DIFF
--- a/native-libs/deps/recipes/monerocorecustom/monerocorecustom.recipe
+++ b/native-libs/deps/recipes/monerocorecustom/monerocorecustom.recipe
@@ -1,6 +1,6 @@
 inherit lib
 
-version="5047cc97a6a279fde1ce11b90d26829a7dd67ea6"
+version="5a878e85333c287944746aba5bc5733ac175129c"
 source="https://github.com/ExodusMovement/monero-core-custom.git#${version}"
 
 build() {

--- a/native-libs/deps/recipes/mymonerocorecpp/CMakeLists.txt
+++ b/native-libs/deps/recipes/mymonerocorecpp/CMakeLists.txt
@@ -17,7 +17,6 @@ set(MONERO_SRC "${MYMONERO_CORE_CPP}/contrib/monero-core-custom")
 include_directories(${MONERO_SRC})
 include_directories("${MONERO_SRC}/epee/include")
 include_directories("${MONERO_SRC}/common")
-include_directories("${MONERO_SRC}/vtlogger")
 include_directories("${MONERO_SRC}/crypto")
 include_directories("${MONERO_SRC}/cryptonote_basic")
 include_directories("${MONERO_SRC}/multisig")
@@ -92,7 +91,7 @@ set(
     ${MONERO_SRC}/ringct/bulletproofs.cc
     ${MONERO_SRC}/ringct/multiexp.cc
     ${MONERO_SRC}/mnemonics/electrum-words.cpp
-    ${MONERO_SRC}/vtlogger/logger.cpp
+    ${MONERO_SRC}/crypto/rx-slow-hash-dummied.cpp
     ${MONERO_SRC}/contrib/libsodium/src/crypto_verify/verify.c
 )
 

--- a/native-libs/deps/recipes/mymonerocorecpp/mymonerocorecpp.recipe
+++ b/native-libs/deps/recipes/mymonerocorecpp/mymonerocorecpp.recipe
@@ -1,7 +1,7 @@
 depends="boost monerocorecustom"
 inherit lib
 
-version="3ef51d0d3e90d94235e56b3f5129cef082e8082c"
+version="b848d85cd6cee24222781b052dee9553e305c1b7"
 source="https://github.com/ExodusMovement/mymonero-core-cpp.git#${version}"
 
 build() {
@@ -42,7 +42,8 @@ build() {
         $install_dir/include/string_tools.h \
         $install_dir/include/warnings.h \
         $install_dir/include/wipeable_string.h \
-        $install_dir/include/logger.h \
+        $install_dir/include/byte_slice.h \
+        $install_dir/include/int-util.h \
         $install_dir/include/cryptonote_config.h
 
     # Replace CMakeLists.txt
@@ -97,9 +98,10 @@ build() {
     cp -f contrib/monero-core-custom/epee/include/string_tools.h $install_dir/include/
     cp -f contrib/monero-core-custom/epee/include/warnings.h $install_dir/include/
     cp -f contrib/monero-core-custom/epee/include/wipeable_string.h $install_dir/include/
+    cp -f contrib/monero-core-custom/epee/include/byte_slice.h $install_dir/include/
+    cp -f contrib/monero-core-custom/epee/include/int-util.h $install_dir/include/
 
     # Copy other
-    cp -f contrib/monero-core-custom/vtlogger/logger.h $install_dir/include/
     cp -f contrib/monero-core-custom/cryptonote_config.h $install_dir/include/
     cp -f src/serial_bridge_index.hpp $install_dir/include/
     cp -f build/libmymonerocorecpp.a $install_dir/lib/


### PR DESCRIPTION
This allows RNFS to compile binaries for Monero v0.17.0.0 code after it's upgraded using this tool: https://github.com/ExodusMovement/monero-updater

Depends on https://github.com/ExodusMovement/monero-core-custom/pull/8
Depends on https://github.com/ExodusMovement/mymonero-core-cpp/pull/13