### PR TITLE
build: add Big Sur support

### DIFF
--- a/native-libs/deps/recipes/boost/boost.recipe
+++ b/native-libs/deps/recipes/boost/boost.recipe
@@ -16,7 +16,7 @@ build_bjam() {
     PREV_CFLAGS=$CFLAGS
     export CC="clang"
     export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-    export CFLAGS="-isysroot $platform_sdk"
+    export CFLAGS="-isysroot $platform_sdk -Wno-implicit-function-declaration"
 
     echo "STARTING X"
 


### PR DESCRIPTION
bjam won't compile with Xcode 12.2 and older Xcode versions don't work on Big Sur.