### PR TITLE
build: skip building native JNI libraries by default

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,8 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def buildLibraries = System.getenv('RNFC_BUILD_LIBRARIES')
+
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 26)
     buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
@@ -43,9 +45,11 @@ android {
         abortOnError false
     }
 
-    externalNativeBuild {
-        cmake {
-            path "src/main/cpp/CMakeLists.txt"
+    if (buildLibraries != null) {
+        externalNativeBuild {
+            cmake {
+                path "src/main/cpp/CMakeLists.txt"
+            }
         }
     }
 
@@ -67,4 +71,3 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
 }
-  

--- a/build-deps
+++ b/build-deps
@@ -2,6 +2,8 @@
 export ZERO_AR_DATE=1
 export SOURCE_DATE_EPOCH=0
 
+export RNFC_BUILD_LIBRARIES=1
+
 NATIVE_TESTS=$NATIVE_TESTS
 
 # List of dependencies that should be rebuilt.


### PR DESCRIPTION
With latest React Native we are hitting an issue with duplicate libnativecrypto.so.
We are prebuilding this file in this package so we want to force this library into apk (instead of whatever developer got when building it locally).

This achieves it by building native libraries only when running with `RNFC_BUILD_LIBRARIES` env. In other cases (so when building RN app that uses this package) it won't be build. This solves the issue with duplicate libraries as well as won't require developers to have NDK set up nor to wait for build to finish.

If someone choses to use local builds of those packages it can be achieved by setting `RNFC_BUILD_LIBRARIES=1` (and resolving duplicate in some other way - packagingOptions/removing jni after deps install).