### PR TITLE
docs: explain building on apple arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ git clone git@github.com:ExodusMovement/react-native-fast-crypto.git /tmp/react-
 cd /tmp/react-native-fast-crypto
 yarn build
 ```
+
+(if you're building on Apple arm, M1 & M2, you can use `arch -x86_64 yarn build` instead of `yarn build`)


### PR DESCRIPTION
I don't really know why this works. We just install the intel ndk and it seems to work fine (maybe Rosetta plays a role?).

Before:
<img width="862" alt="Screenshot 2023-09-05 at 11 27 05 AM" src="https://github.com/ExodusMovement/react-native-fast-crypto/assets/5568717/ce28d138-1011-4f9a-b939-c62c0a669996">

After:
<img width="862" alt="Screenshot 2023-09-05 at 12 21 00 PM" src="https://github.com/ExodusMovement/react-native-fast-crypto/assets/5568717/f1e992ed-aea6-4c61-afe2-4ee03616f7da">
