### PR TITLE
fix: address Java security concerns about Content-Length header

### DIFF
--- a/android/.classpath
+++ b/android/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
-	<classpathentry kind="output" path="bin/default"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,13 +1,2 @@
-arguments=--init-script /var/folders/pj/0g0f09yd39b1wjcyxpqgp6hm0000gn/T/db3b08fc4a9ef609cb16b96b200fa13e563f396e9bb1ed0905fdab7bc3bc513b.gradle --init-script /var/folders/pj/0g0f09yd39b1wjcyxpqgp6hm0000gn/T/52cde0cfcf3e28b8b7510e992210d9614505e0911af0c190bd590d7158574963.gradle
-auto.sync=false
-build.scans.enabled=false
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=
-eclipse.preferences.version=1
-gradle.user.home=
-java.home=/opt/homebrew/Cellar/openjdk@11/11.0.24/libexec/openjdk.jdk/Contents/Home
-jvm.arguments=
-offline.mode=false
-override.workspace.settings=true
-show.console.view=true
-show.executions.view=true
+#Sun Aug 06 08:29:54 PDT 2017
+connection.project.dir=../../../android

--- a/android/src/main/java/co/airbitz/fastcrypto/MoneroAsyncTask.java
+++ b/android/src/main/java/co/airbitz/fastcrypto/MoneroAsyncTask.java
@@ -10,6 +10,7 @@ import org.json.JSONObject;
 
 import java.io.DataInputStream;
 import java.io.OutputStream;
+import java.io.InputStream; 
 import java.io.ByteArrayOutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -179,7 +180,7 @@ public class MoneroAsyncTask extends android.os.AsyncTask<Void, Void, Void> {
     }
     
 
-    private String readAndProcessData(InputStream inputStream, int responseLength, BiFunction<ByteBuffer, String, String> extractUtxos) throws Exception {
+    private String readAndProcessData(InputStream inputStream, long responseLength, BiFunction<ByteBuffer, String, String> extractUtxos) throws Exception {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         byte[] bytes = new byte[8192];
         int bytesRead = 0;

--- a/android/src/main/java/co/airbitz/fastcrypto/MoneroAsyncTask.java
+++ b/android/src/main/java/co/airbitz/fastcrypto/MoneroAsyncTask.java
@@ -165,11 +165,16 @@ public class MoneroAsyncTask extends android.os.AsyncTask<Void, Void, Void> {
         if (contentLengthStr == null) {
             throw new Exception("Missing Content-Length header");
         }
-
+    
         try {
             int contentLength = Integer.parseInt(contentLengthStr);
             if (contentLength < 0) {
                 throw new Exception("Invalid Content-Length header");
+            }
+            // Maximum size set to 100 MB
+            int maxContentLength = 100 * 1024 * 1024; // 100 MB
+            if (contentLength > maxContentLength) {
+                throw new Exception("Content-Length exceeds allowed maximum of 100 MB");
             }
             return contentLength;
         } catch (NumberFormatException e) {

--- a/android/src/main/java/co/airbitz/fastcrypto/MoneroAsyncTask.java
+++ b/android/src/main/java/co/airbitz/fastcrypto/MoneroAsyncTask.java
@@ -10,7 +10,6 @@ import org.json.JSONObject;
 
 import java.io.DataInputStream;
 import java.io.OutputStream;
-import java.io.InputStream; 
 import java.io.ByteArrayOutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -79,9 +78,9 @@ public class MoneroAsyncTask extends android.os.AsyncTask<Void, Void, Void> {
                 connection.connect();
 
                 String contentLengthStr = connection.getHeaderField("Content-Length");
-                long responseLength = validateContentLengthHeader(contentLengthStr);
-                try (InputStream inputStream = connection.getInputStream()) { 
-                    String out = readAndProcessData(inputStream, responseLength, this::extractUtxosFromBlocksResponse);
+                int responseLength = validateContentLengthHeader(contentLengthStr);
+                try (DataInputStream dataInputStream = new DataInputStream(connection.getInputStream())) {
+                    String out = readAndProcessData(dataInputStream, responseLength, this::extractUtxosFromBlocksResponse);
                     promise.resolve(out);
                 }
             } catch (Exception e) {
@@ -95,7 +94,6 @@ public class MoneroAsyncTask extends android.os.AsyncTask<Void, Void, Void> {
         } else if (method.equals("download_from_clarity_and_process")) {
             HttpURLConnection connection = null;
             try {
-                isStopped.set(false);
                 JSONObject params = new JSONObject(jsonParams);
                 String addr = params.getString("url");
                 URL url = new URL(addr);
@@ -108,9 +106,9 @@ public class MoneroAsyncTask extends android.os.AsyncTask<Void, Void, Void> {
                 connection.connect();
 
                 String contentLengthStr = connection.getHeaderField("Content-Length");
-                long responseLength = validateContentLengthHeader(contentLengthStr);
-                try (InputStream inputStream = connection.getInputStream()) { 
-                    String out = readAndProcessData(inputStream, responseLength, this::extractUtxosFromClarityBlocksResponse);
+                int responseLength = validateContentLengthHeader(contentLengthStr);
+                try (DataInputStream dataInputStream = new DataInputStream(connection.getInputStream())) {
+                    String out = readAndProcessData(dataInputStream, responseLength, this::extractUtxosFromClarityBlocksResponse);
                     promise.resolve(out);
                 }
             } catch (Exception e) {
@@ -163,13 +161,13 @@ public class MoneroAsyncTask extends android.os.AsyncTask<Void, Void, Void> {
         return null;
     }
 
-    private long validateContentLengthHeader(String contentLengthStr) throws Exception {
+    private int validateContentLengthHeader(String contentLengthStr) throws Exception {
         if (contentLengthStr == null) {
             throw new Exception("Missing Content-Length header");
         }
 
         try {
-            long contentLength = Long.parseLong(contentLengthStr);
+            int contentLength = Integer.parseInt(contentLengthStr);
             if (contentLength < 0) {
                 throw new Exception("Invalid Content-Length header");
             }
@@ -180,36 +178,35 @@ public class MoneroAsyncTask extends android.os.AsyncTask<Void, Void, Void> {
     }
     
 
-    private String readAndProcessData(InputStream inputStream, long responseLength, BiFunction<ByteBuffer, String, String> extractUtxos) throws Exception {
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        byte[] bytes = new byte[8192];
+    private String readAndProcessData(DataInputStream dataInputStream, int responseLength, BiFunction<ByteBuffer, String, String> extractUtxos) throws Exception {
+        byte[] bytes = new byte[responseLength];
         int bytesRead = 0;
-        long totalBytesRead = 0;
+        int offset = 0;
 
         // Check for cancellation periodically during download
-        while ((bytesRead = inputStream.read(bytes)) != -1) {
+        while (bytesRead != -1 && offset < responseLength) {
             if (isStopped.get()) {
-                throw new IOException("Download stopped by user.");
+                promise.reject("Err", new Exception("Download stopped by user."));
+                return null;
             }
-            outputStream.write(bytes, 0, bytesRead);
-            totalBytesRead += bytesRead;
-            if (responseLength > 0 && totalBytesRead > responseLength) {
-                throw new IOException("Downloaded data exceeds expected Content-Length");
-            }
+            bytesRead = dataInputStream.read(bytes, offset, responseLength - offset);
+            offset += bytesRead;
         }
 
         // Check for cancellation after download is complete
         if (isStopped.get()) {
-            throw new IOException("Processing stopped by user.");
+            promise.reject("Err", new Exception("Processing stopped"));
+            return null;
         }
 
-        ByteBuffer responseBuffer = ByteBuffer.wrap(outputStream.toByteArray());
+        ByteBuffer responseBuffer = ByteBuffer.allocateDirect(responseLength);
+        responseBuffer.put(bytes, 0, responseLength);
         String out = extractUtxos.apply(responseBuffer, jsonParams);
         if (out == null) {
             throw new Exception("Internal error: Memory allocation failed");
         }
 
-        if (isStopped.get()) { 
+        if (isStopped.get()) {
             throw new Exception("Operations are stopped");
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-fast-crypto",
-  "version": "18.3.1-rc.0",
+  "version": "18.3.1-rc.1",
   "description": "Native C/C++ implemented crypto libraries for React Native apps",
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-fast-crypto",
-  "version": "18.3.0",
+  "version": "18.3.1-rc.0",
   "description": "Native C/C++ implemented crypto libraries for React Native apps",
   "keywords": [
     "react-native",


### PR DESCRIPTION
# Summary
Fix potential security issues about Content-Length in Java: https://github.com/ExodusMovement/exodus-mobile/pull/21060#issuecomment-2270916307

- Minor: Revert `android/.classpath` and `android/.settings/org.eclipse.buildship.core.prefs`
- Major: Add a new function to validate the `Content-Length`. We explicitly check for negative and overflowing Content-Length values, throwing an IOException to signal an invalid response. Limit the maximum value of Content-Length is 100 MB (In practice, the maximum file size is only ~22MB).
- Major: optimize the main function to reduce duplicate code.
- Major: Using chunk reading to read the response in 8KB chunks using a byte[] buffer. This prevents loading the entire response into memory at once, mitigating the risk of OutOfMemoryError for large files.